### PR TITLE
CI: Fix name of build dependency USBHostMbed5.

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -48,7 +48,7 @@ jobs:
           libraries: |
             # Install the library from the local path.
             - source-path: ./
-            - source-url: https://github.com/facchinm/USBHostMbed5.git
+            - name: Arduino_USBHostMbed5
           sketch-paths: |
             - examples
           enable-deltas-report: true

--- a/examples/Beginner/Audio_Playback/Audio_Playback.ino
+++ b/examples/Beginner/Audio_Playback/Audio_Playback.ino
@@ -6,8 +6,10 @@
 */
 
 #include <Arduino_AdvancedAnalog.h>
+
+#include <Arduino_USBHostMbed5.h>
+
 #include <DigitalOut.h>
-#include <USBHostMbed5.h>
 #include <FATFileSystem.h>
 
 AdvancedDAC dac1(A12);


### PR DESCRIPTION
It's now Arduino_USBHostMbed5, due to renaming the library to be consistent with Arduino library naming.