### PR TITLE
Fix misspelled word in sketch comment

### DIFF
--- a/examples/Advanced/ADC_Multi_Channel_Dynamic/ADC_Multi_Channel_Dynamic.ino
+++ b/examples/Advanced/ADC_Multi_Channel_Dynamic/ADC_Multi_Channel_Dynamic.ino
@@ -34,7 +34,7 @@ void queryPins() {
         }
     } while (!(c == '\n' || num_active_pins >= AN_MAX_ADC_CHANNELS));
 
-    // No (valid) input? Repeat previous measurement cylce
+    // No (valid) input? Repeat previous measurement cycle
     if (!num_active_pins) {
         num_active_pins = old_num_active_pins;
     }


### PR DESCRIPTION
The [**codespell**](https://github.com/codespell-project/codespell) tool is used for automated detection of common misspellings in the files of this project.

A new release of codespell includes an expansion of its misspellings dictionary. The new version was able to catch a previously undetected typo in a sketch comment:

https://github.com/arduino-libraries/Arduino_AdvancedAnalog/actions/runs/6390304186/job/17343291223#step:4:17

```text
Error: ./examples/Advanced/ADC_Multi_Channel_Dynamic/ADC_Multi_Channel_Dynamic.ino:37: cylce ==> cycle
```

The misspelled word is corrected here.