### PR TITLE
Support synchronized ADC capture

### DIFF
--- a/src/AdvancedADC.cpp
+++ b/src/AdvancedADC.cpp
@@ -115,7 +115,7 @@ DMABuffer<Sample> &AdvancedADC::read() {
     return NULLBUF;
 }
 
-int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers,bool noStart=false) {
+int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers,bool noStart) {
     
     ADCName instance = ADC_NP;
     // Sanity checks.

--- a/src/AdvancedADC.cpp
+++ b/src/AdvancedADC.cpp
@@ -218,7 +218,9 @@ int AdvancedADC::start(uint32_t sample_rate) {
     }
 
     // Re/enable DMA double buffer mode.
+    HAL_NVIC_DisableIRQ(descr->dma_irqn);
     hal_dma_enable_dbm(&descr->dma, descr->dmabuf[0]->data(), descr->dmabuf[1]->data());
+    HAL_NVIC_EnableIRQ(descr->dma_irqn);
 
     // Init, config and start the ADC timer.
     hal_tim_config(&descr->tim, sample_rate);

--- a/src/AdvancedADC.cpp
+++ b/src/AdvancedADC.cpp
@@ -116,7 +116,6 @@ DMABuffer<Sample> &AdvancedADC::read() {
 }
 
 int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers, bool start) {
-    
     ADCName instance = ADC_NP;
     // Sanity checks.
     if (resolution >= AN_ARRAY_SIZE(ADC_RES_LUT) || (descr && descr->pool)) {

--- a/src/AdvancedADC.cpp
+++ b/src/AdvancedADC.cpp
@@ -210,7 +210,7 @@ int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_sampl
     return 1;
 }
 
-int AdvancedADC::start(uint32_t sample_rate) {
+int AdvancedADC::start() {
     // Link DMA handle to ADC handle, and start the ADC.
     __HAL_LINKDMA(&descr->adc, DMA_Handle, descr->dma);
     if (HAL_ADC_Start_DMA(&descr->adc, (uint32_t *) descr->dmabuf[0]->data(), descr->dmabuf[0]->size()) != HAL_OK) {

--- a/src/AdvancedADC.cpp
+++ b/src/AdvancedADC.cpp
@@ -115,7 +115,7 @@ DMABuffer<Sample> &AdvancedADC::read() {
     return NULLBUF;
 }
 
-int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers,bool noStart) {
+int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers, bool start) {
     
     ADCName instance = ADC_NP;
     // Sanity checks.

--- a/src/AdvancedADC.cpp
+++ b/src/AdvancedADC.cpp
@@ -202,9 +202,10 @@ int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_sampl
         return 0;
     }
 
-    // Start sampling immediately unless start==false.
-    if (start) {  
-        return start(sample_rate);
+    sampling_rate = sample_rate;
+    // Start sampling immediately unless start_sampling==false.
+    if (start_sampling) {  
+        return start();
     }
 
     return 1;

--- a/src/AdvancedADC.cpp
+++ b/src/AdvancedADC.cpp
@@ -210,10 +210,7 @@ int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_sampl
     return 1;
 }
 
-int AdvancedADC::start(uint32_t sample_rate){
-
-    //This routine links adc and dma already setup via the begin() function, and then starts ADC capture timer
-
+int AdvancedADC::start(uint32_t sample_rate) {
     // Link DMA handle to ADC handle, and start the ADC.
     __HAL_LINKDMA(&descr->adc, DMA_Handle, descr->dma);
     if (HAL_ADC_Start_DMA(&descr->adc, (uint32_t *) descr->dmabuf[0]->data(), descr->dmabuf[0]->size()) != HAL_OK) {

--- a/src/AdvancedADC.cpp
+++ b/src/AdvancedADC.cpp
@@ -115,7 +115,7 @@ DMABuffer<Sample> &AdvancedADC::read() {
     return NULLBUF;
 }
 
-int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers, bool start) {
+int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers, bool start_sampling) {
     ADCName instance = ADC_NP;
     // Sanity checks.
     if (resolution >= AN_ARRAY_SIZE(ADC_RES_LUT) || (descr && descr->pool)) {

--- a/src/AdvancedADC.cpp
+++ b/src/AdvancedADC.cpp
@@ -238,9 +238,10 @@ int AdvancedADC::stop()
     return 1;
 }
 
-void AdvancedADC::clear()
-{
-    descr->pool->flush();
+void AdvancedADC::clear() {
+    if (descr && descr->pool) {
+        descr->pool->flush();
+    }
 }
 
 AdvancedADC::~AdvancedADC()

--- a/src/AdvancedADC.cpp
+++ b/src/AdvancedADC.cpp
@@ -202,9 +202,9 @@ int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_sampl
         return 0;
     }
 
-    //if noStart is not set, proceed with starting ADC capture
-    if(!noStart) {  
-        return(start(sample_rate));
+    // Start sampling immediately unless start==false.
+    if (start) {  
+        return start(sample_rate);
     }
 
     return 1;

--- a/src/AdvancedADC.cpp
+++ b/src/AdvancedADC.cpp
@@ -115,19 +115,19 @@ DMABuffer<Sample> &AdvancedADC::read() {
     return NULLBUF;
 }
 
-int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers) {
+int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers,bool noStart=false) {
+    
     ADCName instance = ADC_NP;
-
     // Sanity checks.
     if (resolution >= AN_ARRAY_SIZE(ADC_RES_LUT) || (descr && descr->pool)) {
         return 0;
     }
-
+  
     // Clear ALTx pin.
     for (size_t i=0; i<n_channels; i++) {
         adc_pins[i] =  (PinName) (adc_pins[i] & ~(ADC_PIN_ALT_MASK));
     }
-    
+
     // Find an ADC that can be used with these set of pins/channels.
     for (size_t i=0; instance == ADC_NP && i<AN_ARRAY_SIZE(adc_pin_alt); i++) {
         // Calculate alternate function pin.
@@ -188,8 +188,10 @@ int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_sampl
     if (descr->pool == nullptr) {
         return 0;
     }
+
     descr->dmabuf[0] = descr->pool->allocate();
     descr->dmabuf[1] = descr->pool->allocate();
+
 
     // Init and config DMA.
     if (hal_dma_config(&descr->dma, descr->dma_irqn, DMA_PERIPH_TO_MEMORY) < 0) {
@@ -201,118 +203,17 @@ int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_sampl
         return 0;
     }
 
-    // Link DMA handle to ADC handle, and start the ADC.
-    __HAL_LINKDMA(&descr->adc, DMA_Handle, descr->dma);
-    if (HAL_ADC_Start_DMA(&descr->adc, (uint32_t *) descr->dmabuf[0]->data(), descr->dmabuf[0]->size()) != HAL_OK) {
-        return 0;
+    //if noStart is not set, proceed with starting ADC capture
+    if(!noStart) {  
+        return(start(sample_rate));
     }
 
-    // Re/enable DMA double buffer mode.
-    HAL_NVIC_DisableIRQ(descr->dma_irqn);
-    hal_dma_enable_dbm(&descr->dma, descr->dmabuf[0]->data(), descr->dmabuf[1]->data());
-    HAL_NVIC_EnableIRQ(descr->dma_irqn);
-
-    // Init, config and start the ADC timer.
-    hal_tim_config(&descr->tim, sample_rate);
-    if (HAL_TIM_Base_Start(&descr->tim) != HAL_OK) {
-        return 0;
-    }
-    
     return 1;
 }
 
-int AdvancedADC::ready(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers) {
-    ADCName instance = ADC_NP;
+int AdvancedADC::start(uint32_t sample_rate){
 
-    // Sanity checks.
-    if (resolution >= AN_ARRAY_SIZE(ADC_RES_LUT) || (descr && descr->pool)) {
-        return 0;
-    }
-
-    // Clear ALTx pin.
-    for (size_t i=0; i<n_channels; i++) {
-        adc_pins[i] =  (PinName) (adc_pins[i] & ~(ADC_PIN_ALT_MASK));
-    }
-
-    // Find an ADC that can be used with these set of pins/channels.
-    for (size_t i=0; instance == ADC_NP && i<AN_ARRAY_SIZE(adc_pin_alt); i++) {
-        // Calculate alternate function pin.
-        PinName pin = (PinName) (adc_pins[0] | adc_pin_alt[i]); // First pin decides the ADC.
-
-        // Check if pin is mapped.
-        if (pinmap_find_peripheral(pin, PinMap_ADC) == NC) {
-            break;
-        }
-
-        // Find the first free ADC according to the available ADCs on pin.
-        for (size_t j=0; instance == ADC_NP && j<AN_ARRAY_SIZE(adc_descr_all); j++) {
-            descr = &adc_descr_all[j];
-            if (descr->pool == nullptr) {
-                ADCName tmp_instance = (ADCName) pinmap_peripheral(pin, PinMap_ADC);
-                if (descr->adc.Instance == ((ADC_TypeDef*) tmp_instance)) {
-                    instance = tmp_instance;
-                    adc_pins[0] = pin;
-                }
-            }
-        }
-    }
-
-    if (instance == ADC_NP) {
-        // Couldn't find a free ADC/descriptor.
-        descr = nullptr;
-        return 0;
-    }
-
-    // Configure ADC pins.
-    pinmap_pinout(adc_pins[0], PinMap_ADC);
-    uint8_t ch_init = 1;
-    for (size_t i=1; i<n_channels; i++) {
-        for (size_t j=0; j<AN_ARRAY_SIZE(adc_pin_alt); j++) {
-            // Calculate alternate function pin.
-            PinName pin = (PinName) (adc_pins[i] | adc_pin_alt[j]);
-            // Check if pin is mapped.
-            if (pinmap_find_peripheral(pin, PinMap_ADC) == NC) {
-                break;
-            }
-            // Check if pin is connected to the selected ADC.
-            if (instance == pinmap_peripheral(pin, PinMap_ADC)) {
-                pinmap_pinout(pin, PinMap_ADC);
-                adc_pins[i] = pin;
-                ch_init++;
-                break;
-            }
-        }
-    }
-
-    // All channels must share the same instance; if not, bail out.
-    if (ch_init < n_channels) {
-        return 0;
-    }
-
-    // Allocate DMA buffer pool.
-    descr->pool = new DMABufferPool<Sample>(n_samples, n_channels, n_buffers);
-    if (descr->pool == nullptr) {
-        return 0;
-    }
-
-    descr->dmabuf[0] = descr->pool->allocate();
-    descr->dmabuf[1] = descr->pool->allocate();
-
-
-    // Init and config DMA.
-    if (hal_dma_config(&descr->dma, descr->dma_irqn, DMA_PERIPH_TO_MEMORY) < 0) {
-        return 0;
-    }
-
-    if (hal_adc_config(&descr->adc, ADC_RES_LUT[resolution], descr->tim_trig, adc_pins, n_channels) < 0) {
-        return 0;
-    }
-
-   return(1);
-}
-
-int AdvancedADC::start(uint32_t sample_rate)
-{
+    //This routine links adc and dma already setup via the begin() function, and then starts ADC capture timer
 
     // Link DMA handle to ADC handle, and start the ADC.
     __HAL_LINKDMA(&descr->adc, DMA_Handle, descr->dma);

--- a/src/AdvancedADC.cpp
+++ b/src/AdvancedADC.cpp
@@ -122,7 +122,6 @@ int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_sampl
     if (resolution >= AN_ARRAY_SIZE(ADC_RES_LUT) || (descr && descr->pool)) {
         return 0;
     }
-  
     // Clear ALTx pin.
     for (size_t i=0; i<n_channels; i++) {
         adc_pins[i] =  (PinName) (adc_pins[i] & ~(ADC_PIN_ALT_MASK));

--- a/src/AdvancedADC.h
+++ b/src/AdvancedADC.h
@@ -55,6 +55,17 @@ class AdvancedADC {
             n_channels = n_pins;
             return begin(resolution, sample_rate, n_samples, n_buffers);
         }
+        void clear();  //clears any existing DMA buffers from read queue
+        int ready(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers);
+        int ready(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers, size_t n_pins, pin_size_t *pins) {
+            if (n_pins > AN_MAX_ADC_CHANNELS) n_pins = AN_MAX_ADC_CHANNELS;
+            for (size_t i = 0; i < n_pins; ++i) {
+                adc_pins[i] = analogPinToPinName(pins[i]);
+            }
+            n_channels = n_pins;
+            return ready(resolution, sample_rate, n_samples, n_buffers);
+        }
+        int start(uint32_t sample_rate);
         int stop();
 };
 

--- a/src/AdvancedADC.h
+++ b/src/AdvancedADC.h
@@ -46,7 +46,7 @@ class AdvancedADC {
         ~AdvancedADC();
         bool available();
         SampleBuffer read();
-        int begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers, bool noStart=false);
+        int begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers, bool start_sampling = true);
         int begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers, size_t n_pins, pin_size_t *pins, bool noStart=false) {
             if (n_pins > AN_MAX_ADC_CHANNELS) n_pins = AN_MAX_ADC_CHANNELS;
             for (size_t i = 0; i < n_pins; ++i) {

--- a/src/AdvancedADC.h
+++ b/src/AdvancedADC.h
@@ -46,7 +46,7 @@ class AdvancedADC {
         ~AdvancedADC();
         bool available();
         SampleBuffer read();
-        int begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers, bool noStart);
+        int begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers, bool noStart=false);
         int begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers, size_t n_pins, pin_size_t *pins, bool noStart=false) {
             if (n_pins > AN_MAX_ADC_CHANNELS) n_pins = AN_MAX_ADC_CHANNELS;
             for (size_t i = 0; i < n_pins; ++i) {

--- a/src/AdvancedADC.h
+++ b/src/AdvancedADC.h
@@ -47,7 +47,7 @@ class AdvancedADC {
         bool available();
         SampleBuffer read();
         int begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers, bool start_sampling = true);
-        int begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers, size_t n_pins, pin_size_t *pins, bool noStart=false) {
+        int begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers, size_t n_pins, pin_size_t *pins, bool start_sampling = true) {
             if (n_pins > AN_MAX_ADC_CHANNELS) n_pins = AN_MAX_ADC_CHANNELS;
             for (size_t i = 0; i < n_pins; ++i) {
                 adc_pins[i] = analogPinToPinName(pins[i]);

--- a/src/AdvancedADC.h
+++ b/src/AdvancedADC.h
@@ -46,25 +46,17 @@ class AdvancedADC {
         ~AdvancedADC();
         bool available();
         SampleBuffer read();
-        int begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers);
-        int begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers, size_t n_pins, pin_size_t *pins) {
+        int begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers, bool noStart);
+        int begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers, size_t n_pins, pin_size_t *pins, bool noStart=false) {
             if (n_pins > AN_MAX_ADC_CHANNELS) n_pins = AN_MAX_ADC_CHANNELS;
             for (size_t i = 0; i < n_pins; ++i) {
                 adc_pins[i] = analogPinToPinName(pins[i]);
             }
             n_channels = n_pins;
-            return begin(resolution, sample_rate, n_samples, n_buffers);
+            return begin(resolution, sample_rate, n_samples, n_buffers,noStart);
         }
-        void clear();  //clears any existing DMA buffers from read queue
-        int ready(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers);
-        int ready(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers, size_t n_pins, pin_size_t *pins) {
-            if (n_pins > AN_MAX_ADC_CHANNELS) n_pins = AN_MAX_ADC_CHANNELS;
-            for (size_t i = 0; i < n_pins; ++i) {
-                adc_pins[i] = analogPinToPinName(pins[i]);
-            }
-            n_channels = n_pins;
-            return ready(resolution, sample_rate, n_samples, n_buffers);
-        }
+        void clear();
+
         int start(uint32_t sample_rate);
         int stop();
 };

--- a/src/AdvancedADC.h
+++ b/src/AdvancedADC.h
@@ -53,7 +53,7 @@ class AdvancedADC {
                 adc_pins[i] = analogPinToPinName(pins[i]);
             }
             n_channels = n_pins;
-            return begin(resolution, sample_rate, n_samples, n_buffers,noStart);
+            return begin(resolution, sample_rate, n_samples, n_buffers, start);
         }
         void clear();
 

--- a/src/AdvancedADC.h
+++ b/src/AdvancedADC.h
@@ -56,7 +56,7 @@ class AdvancedADC {
             return begin(resolution, sample_rate, n_samples, n_buffers, start);
         }
         void clear();
-        int start(uint32_t sample_rate);
+        int start();
         int stop();
 };
 

--- a/src/AdvancedADC.h
+++ b/src/AdvancedADC.h
@@ -53,7 +53,7 @@ class AdvancedADC {
                 adc_pins[i] = analogPinToPinName(pins[i]);
             }
             n_channels = n_pins;
-            return begin(resolution, sample_rate, n_samples, n_buffers, start);
+            return begin(resolution, sample_rate, n_samples, n_buffers, start_sampling);
         }
         void clear();
         int start();

--- a/src/AdvancedADC.h
+++ b/src/AdvancedADC.h
@@ -56,7 +56,6 @@ class AdvancedADC {
             return begin(resolution, sample_rate, n_samples, n_buffers, start);
         }
         void clear();
-
         int start(uint32_t sample_rate);
         int stop();
 };


### PR DESCRIPTION
The `begin()` function takes about 106us to execute. If you're trying to start two ADCs, this will mean the first ADC will already be capturing for at least 106us when you execute the `ADC.begin()` on the second one.  

The changes proposed here allow the following semantics:

```
adc1.ready(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers);
adc2.ready(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers);

adc1.start(sample_rate);
adc2.start(sample_rate);
```

This reduces the skew between the two captures to about 4us.  