### PR TITLE
Add ADC Dual Mode support with new AdvancedADCDual class

### DIFF
--- a/src/AdvancedADC.cpp
+++ b/src/AdvancedADC.cpp
@@ -115,42 +115,73 @@ DMABuffer<Sample> &AdvancedADC::read() {
     return NULLBUF;
 }
 
-int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers) {
+int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers,bool do_start,uint8_t adcNum) {
+    
     ADCName instance = ADC_NP;
-
     // Sanity checks.
     if (resolution >= AN_ARRAY_SIZE(ADC_RES_LUT) || (descr && descr->pool)) {
         return 0;
     }
 
+    //if ADC specified is more than the number of available ADC bail out
+    if(adcNum>AN_ARRAY_SIZE(adc_pin_alt))
+    {
+        descr = nullptr;
+        return 0;
+    }
+  
     // Clear ALTx pin.
     for (size_t i=0; i<n_channels; i++) {
         adc_pins[i] =  (PinName) (adc_pins[i] & ~(ADC_PIN_ALT_MASK));
     }
     
-    // Find an ADC that can be used with these set of pins/channels.
-    for (size_t i=0; instance == ADC_NP && i<AN_ARRAY_SIZE(adc_pin_alt); i++) {
-        // Calculate alternate function pin.
-        PinName pin = (PinName) (adc_pins[0] | adc_pin_alt[i]); // First pin decides the ADC.
 
-        // Check if pin is mapped.
-        if (pinmap_find_peripheral(pin, PinMap_ADC) == NC) {
-            break;
-        }
+    // If ADC not specified find an ADC that can be used with these set of pins/channels.
+    if(adcNum==0)
+    {
+        for (size_t i=0; instance == ADC_NP && i<AN_ARRAY_SIZE(adc_pin_alt); i++) {
+            // Calculate alternate function pin.
+            PinName pin = (PinName) (adc_pins[0] | adc_pin_alt[i]); // First pin decides the ADC.
 
-        // Find the first free ADC according to the available ADCs on pin.
-        for (size_t j=0; instance == ADC_NP && j<AN_ARRAY_SIZE(adc_descr_all); j++) {
-            descr = &adc_descr_all[j];
-            if (descr->pool == nullptr) {
-                ADCName tmp_instance = (ADCName) pinmap_peripheral(pin, PinMap_ADC);
-                if (descr->adc.Instance == ((ADC_TypeDef*) tmp_instance)) {
-                    instance = tmp_instance;
-                    adc_pins[0] = pin;
+            // Check if pin is mapped.
+            if (pinmap_find_peripheral(pin, PinMap_ADC) == NC) {
+                break;
+            }
+
+            // Find the first free ADC according to the available ADCs on pin.
+            for (size_t j=0; instance == ADC_NP && j<AN_ARRAY_SIZE(adc_descr_all); j++) {
+                descr = &adc_descr_all[j];
+                if (descr->pool == nullptr) {
+                    ADCName tmp_instance = (ADCName) pinmap_peripheral(pin, PinMap_ADC);
+                    if (descr->adc.Instance == ((ADC_TypeDef*) tmp_instance)) {
+                        instance = tmp_instance;
+                        adc_pins[0] = pin;
+                        selectedADC=j;
+                    }
                 }
             }
         }
     }
+    else if(adcNum>0)  //if ADC specified use that ADC to try to map first channel
+    {
+        PinName pin = (PinName) (adc_pins[0] | adc_pin_alt[adcNum-1]); 
 
+        // Check if pin is mapped.
+        if (pinmap_find_peripheral(pin, PinMap_ADC) == NC) {
+            return 0;
+        }
+   
+        descr = &adc_descr_all[adcNum-1];
+        if (descr->pool == nullptr) {
+            ADCName tmp_instance = (ADCName) pinmap_peripheral(pin, PinMap_ADC);
+            if (descr->adc.Instance == ((ADC_TypeDef*) tmp_instance)) {
+                instance = tmp_instance;
+                adc_pins[0] = pin;
+            }
+        }
+        selectedADC=adcNum; //Store selected number
+    }
+    
     if (instance == ADC_NP) {
         // Couldn't find a free ADC/descriptor.
         descr = nullptr;
@@ -159,11 +190,40 @@ int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_sampl
 
     // Configure ADC pins.
     pinmap_pinout(adc_pins[0], PinMap_ADC);
-    uint8_t ch_init = 1;
-    for (size_t i=1; i<n_channels; i++) {
-        for (size_t j=0; j<AN_ARRAY_SIZE(adc_pin_alt); j++) {
+    
+    //If ADC was not specified ensure the remaining channels are mappable to same ADC
+    if(adcNum==0)
+    {
+        uint8_t ch_init = 1;
+        for (size_t i=1; i<n_channels; i++) {
+            for (size_t j=0; j<AN_ARRAY_SIZE(adc_pin_alt); j++) {
+                // Calculate alternate function pin.
+                PinName pin = (PinName) (adc_pins[i] | adc_pin_alt[j]);
+                // Check if pin is mapped.
+                if (pinmap_find_peripheral(pin, PinMap_ADC) == NC) {
+                    break;
+                }
+                // Check if pin is connected to the selected ADC.
+                if (instance == pinmap_peripheral(pin, PinMap_ADC)) {
+                    pinmap_pinout(pin, PinMap_ADC);
+                    adc_pins[i] = pin;
+                    ch_init++;
+                    break;
+                }
+            }
+        }
+        // All channels must share the same instance; if not, bail out.
+        if (ch_init < n_channels) {
+            return 0;
+        }
+    }
+    else if(adcNum>0)  //If specific ADC was requested ensure all other channels map to that same ADC
+    {
+        uint8_t ch_init = 1;
+        for (size_t i=1; i<n_channels; i++) {
+            
             // Calculate alternate function pin.
-            PinName pin = (PinName) (adc_pins[i] | adc_pin_alt[j]);
+            PinName pin = (PinName) (adc_pins[i] | adc_pin_alt[adcNum-1]);
             // Check if pin is mapped.
             if (pinmap_find_peripheral(pin, PinMap_ADC) == NC) {
                 break;
@@ -173,21 +233,22 @@ int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_sampl
                 pinmap_pinout(pin, PinMap_ADC);
                 adc_pins[i] = pin;
                 ch_init++;
-                break;
             }
         }
+        // All channels must share the same instance; if not, bail out.
+        if (ch_init < n_channels) {
+            return 0;
+        }
     }
-
-    // All channels must share the same instance; if not, bail out.
-    if (ch_init < n_channels) {
-        return 0;
-    }
-
+    
+    
     // Allocate DMA buffer pool.
     descr->pool = new DMABufferPool<Sample>(n_samples, n_channels, n_buffers);
     if (descr->pool == nullptr) {
         return 0;
     }
+
+    //Allocate two DMA buffers for double buffering
     descr->dmabuf[0] = descr->pool->allocate();
     descr->dmabuf[1] = descr->pool->allocate();
 
@@ -202,7 +263,7 @@ int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_sampl
     }
 
     // Link DMA handle to ADC handle, and start the ADC.
-    __HAL_LINKDMA(&descr->adc, DMA_Handle, descr->dma);
+     __HAL_LINKDMA(&descr->adc, DMA_Handle, descr->dma);
     if (HAL_ADC_Start_DMA(&descr->adc, (uint32_t *) descr->dmabuf[0]->data(), descr->dmabuf[0]->size()) != HAL_OK) {
         return 0;
     }
@@ -212,12 +273,24 @@ int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_sampl
     hal_dma_enable_dbm(&descr->dma, descr->dmabuf[0]->data(), descr->dmabuf[1]->data());
     HAL_NVIC_EnableIRQ(descr->dma_irqn);
 
+    if(do_start)
+    {
+        return(start(sample_rate));
+    }
+
+    return 1;
+}
+
+int AdvancedADC::start(uint32_t sample_rate)
+{
     // Init, config and start the ADC timer.
     hal_tim_config(&descr->tim, sample_rate);
+    
+    //Start Timer and ADC Capture.  If Dual Mode was enabled, then this will also start ADC2
     if (HAL_TIM_Base_Start(&descr->tim) != HAL_OK) {
         return 0;
     }
-    
+
     return 1;
 }
 
@@ -227,9 +300,68 @@ int AdvancedADC::stop()
     return 1;
 }
 
+void AdvancedADC::clear()
+{
+    descr->pool->flush();
+}
+
 AdvancedADC::~AdvancedADC()
 {
     dac_descr_deinit(descr, true);
+}
+
+int AdvancedADCDual::begin(AdvancedADC *in1, AdvancedADC *in2,uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers)
+{
+	adcIN1=in1;
+	adcIN2=in2;
+	
+	int result=0;
+	
+	//Configure first pin on ADC1
+	result=adcIN1->begin(resolution,sample_rate,n_samples,n_buffers,1,&(adc_pins_unmapped[0]),false,1);
+	if(result!=1)
+	{
+		return(0);
+	}
+	//Configure all other pins on ADC2
+	result=adcIN2->begin(resolution,sample_rate,n_samples,n_buffers,n_channels-1,&(adc_pins_unmapped[1]),false,2);
+	if(result!=1)
+	{
+		return(0);
+	}
+	
+	result=hal_enable_dual_mode();
+	
+	result=adcIN1->start(sample_rate);
+	
+	if(result!=1)
+	{
+		return(0);
+	}
+	
+	return(1);
+	
+}
+
+int AdvancedADCDual:: stop()
+{
+	if(adcIN1!=nullptr)
+	{
+		adcIN1->stop();
+	}
+    if(adcIN2!=nullptr)
+    {
+        adcIN2->stop();
+    }
+    //Always disable dual mode when stopped
+	int result=hal_disable_dual_mode();
+    return(1);
+	
+}
+
+AdvancedADCDual::~AdvancedADCDual()
+{
+    int result=stop();
 }
 
 extern "C" {

--- a/src/AdvancedADC.cpp
+++ b/src/AdvancedADC.cpp
@@ -115,7 +115,7 @@ DMABuffer<Sample> &AdvancedADC::read() {
     return NULLBUF;
 }
 
-int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers,bool do_start,uint8_t adcNum) {
+int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers, bool do_start, uint8_t adcNum) {
     
     ADCName instance = ADC_NP;
     // Sanity checks.
@@ -124,8 +124,7 @@ int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_sampl
     }
 
     //if ADC specified is more than the number of available ADC bail out
-    if(adcNum>AN_ARRAY_SIZE(adc_pin_alt))
-    {
+    if(adcNum>AN_ARRAY_SIZE(adc_pin_alt)) {
         descr = nullptr;
         return 0;
     }
@@ -137,8 +136,7 @@ int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_sampl
     
 
     // If ADC not specified find an ADC that can be used with these set of pins/channels.
-    if(adcNum==0)
-    {
+    if(adcNum==0) {
         for (size_t i=0; instance == ADC_NP && i<AN_ARRAY_SIZE(adc_pin_alt); i++) {
             // Calculate alternate function pin.
             PinName pin = (PinName) (adc_pins[0] | adc_pin_alt[i]); // First pin decides the ADC.
@@ -162,8 +160,7 @@ int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_sampl
             }
         }
     }
-    else if(adcNum>0)  //if ADC specified use that ADC to try to map first channel
-    {
+    else if(adcNum>0) { //if ADC specified use that ADC to try to map first channel
         PinName pin = (PinName) (adc_pins[0] | adc_pin_alt[adcNum-1]); 
 
         // Check if pin is mapped.
@@ -192,8 +189,7 @@ int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_sampl
     pinmap_pinout(adc_pins[0], PinMap_ADC);
     
     //If ADC was not specified ensure the remaining channels are mappable to same ADC
-    if(adcNum==0)
-    {
+    if(adcNum==0) {
         uint8_t ch_init = 1;
         for (size_t i=1; i<n_channels; i++) {
             for (size_t j=0; j<AN_ARRAY_SIZE(adc_pin_alt); j++) {
@@ -273,16 +269,14 @@ int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_sampl
     hal_dma_enable_dbm(&descr->dma, descr->dmabuf[0]->data(), descr->dmabuf[1]->data());
     HAL_NVIC_EnableIRQ(descr->dma_irqn);
 
-    if(do_start)
-    {
+    if(do_start){
         return(start(sample_rate));
     }
 
     return 1;
 }
 
-int AdvancedADC::start(uint32_t sample_rate)
-{
+int AdvancedADC::start(uint32_t sample_rate){
     // Init, config and start the ADC timer.
     hal_tim_config(&descr->tim, sample_rate);
     
@@ -294,24 +288,22 @@ int AdvancedADC::start(uint32_t sample_rate)
     return 1;
 }
 
-int AdvancedADC::stop()
-{
+int AdvancedADC::stop(){
+
     dac_descr_deinit(descr, true);
+
     return 1;
 }
 
-void AdvancedADC::clear()
-{
+void AdvancedADC::clear() {
     descr->pool->flush();
 }
 
-AdvancedADC::~AdvancedADC()
-{
+AdvancedADC::~AdvancedADC(){
     dac_descr_deinit(descr, true);
 }
 
-int AdvancedADCDual::begin(AdvancedADC *in1, AdvancedADC *in2,uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers)
-{
+int AdvancedADCDual::begin(AdvancedADC *in1, AdvancedADC *in2, uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers){
 	adcIN1=in1;
 	adcIN2=in2;
 	
@@ -343,8 +335,7 @@ int AdvancedADCDual::begin(AdvancedADC *in1, AdvancedADC *in2,uint32_t resolutio
 	
 }
 
-int AdvancedADCDual:: stop()
-{
+int AdvancedADCDual:: stop(){
 	if(adcIN1!=nullptr)
 	{
 		adcIN1->stop();
@@ -356,11 +347,9 @@ int AdvancedADCDual:: stop()
     //Always disable dual mode when stopped
 	int result=hal_disable_dual_mode();
     return(1);
-	
 }
 
-AdvancedADCDual::~AdvancedADCDual()
-{
+AdvancedADCDual::~AdvancedADCDual(){
     int result=stop();
 }
 

--- a/src/AdvancedADC.cpp
+++ b/src/AdvancedADC.cpp
@@ -267,14 +267,12 @@ int AdvancedADCDual::begin(AdvancedADC *in1, AdvancedADC *in2, uint32_t resoluti
 	result=adcIN1->begin(resolution,sample_rate,n_samples,n_buffers,1,&(adc_pins_unmapped[0]),false);
 	if(result!=1 || adcIN1->getAssignedADC()!=1)
 	{
-        Serial.println("First ADC Assigned: "+String(adcIN1->getAssignedADC()));
 		return(0);
 	}
 	//Configure all other pins on ADC2
 	result=adcIN2->begin(resolution,sample_rate,n_samples,n_buffers,n_channels-1,&(adc_pins_unmapped[1]),false);
 	if(result!=1 || adcIN2->getAssignedADC()!=2)
 	{
-        Serial.println("Second ADC Assigned: "+String(adcIN1->getAssignedADC()));
 		return(0);
 	}
 	

--- a/src/AdvancedADC.h
+++ b/src/AdvancedADC.h
@@ -31,6 +31,8 @@ class AdvancedADC {
         size_t n_channels;
         adc_descr_t *descr;
         PinName adc_pins[AN_MAX_ADC_CHANNELS];
+        bool dualMode;
+        uint8_t selectedADC;
 
     public:
         template <typename ... T>
@@ -41,21 +43,74 @@ class AdvancedADC {
             for (auto p : {p0, args...}) {
                 adc_pins[n_channels++] = analogPinToPinName(p);
             }
+            dualMode=false;
+            selectedADC=0;
         }
         AdvancedADC(): n_channels(0), descr(nullptr) {}
         ~AdvancedADC();
         bool available();
         SampleBuffer read();
-        int begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers);
-        int begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers, size_t n_pins, pin_size_t *pins) {
+        int begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers, bool do_start=true,uint8_t adcNum=0);
+        int begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers, size_t n_pins, pin_size_t *pins, bool start=true,uint8_t fixed_adc=0) {
             if (n_pins > AN_MAX_ADC_CHANNELS) n_pins = AN_MAX_ADC_CHANNELS;
             for (size_t i = 0; i < n_pins; ++i) {
                 adc_pins[i] = analogPinToPinName(pins[i]);
             }
+
             n_channels = n_pins;
-            return begin(resolution, sample_rate, n_samples, n_buffers);
+            return begin(resolution, sample_rate, n_samples, n_buffers,start,fixed_adc);
         }
+        
+        void clear();
+
+        int start(uint32_t sample_rate);
+        
+        //void setADCDualMode(bool dm);
+        //int enableDualMode();
+        //int disableDualMode();
+        
         int stop();
+};
+
+class AdvancedADCDual {
+		private:
+			size_t n_channels;
+			pin_size_t adc_pins_unmapped[AN_MAX_ADC_CHANNELS];
+			AdvancedADC *adcIN1;
+			AdvancedADC *adcIN2;
+		public:
+			
+			//For now ADC1 will always be one pin, and ADC2 will sample the rest
+			template <typename ... T>
+			AdvancedADCDual(pin_size_t p0, T ... args):n_channels(0), adcIN1(nullptr), adcIN2(nullptr){
+				static_assert(sizeof ...(args) < AN_MAX_ADC_CHANNELS+1,
+                    "A maximum of 5 channels can be sampled successively.");
+				static_assert (sizeof ...(args) >=2,
+					"At least two channels are required for Dual Mode ADC.");
+				for (auto p : {p0, args...}) {
+					adc_pins_unmapped[n_channels++] = p;
+                 }
+            }
+			
+			AdvancedADCDual(): n_channels(0), adcIN1(nullptr), adcIN2(nullptr)
+			{
+			}
+            ~AdvancedADCDual();
+
+			int begin(AdvancedADC *in1, AdvancedADC *in2,uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers);
+			int begin(AdvancedADC *in1, AdvancedADC *in2,uint32_t resolution, uint32_t sample_rate, 
+				size_t n_samples, size_t n_buffers, size_t n_pins, pin_size_t *pins) {
+            if (n_pins > AN_MAX_ADC_CHANNELS) n_pins = AN_MAX_ADC_CHANNELS;
+            if(n_pins<2)  //Cannot run Dual mode with less than two input pins
+                return(0);
+            for (size_t i = 0; i < n_pins; ++i) {
+                adc_pins_unmapped[i] = pins[i];
+                Serial.println("Pin: "+String(pins[i]));
+            }
+            n_channels = n_pins;
+            return begin(in1, in2, resolution, sample_rate, n_samples, n_buffers);
+        }
+			int stop();
 };
 
 #endif /* ARDUINO_ADVANCED_ADC_H_ */

--- a/src/AdvancedADC.h
+++ b/src/AdvancedADC.h
@@ -32,7 +32,7 @@ class AdvancedADC {
         adc_descr_t *descr;
         PinName adc_pins[AN_MAX_ADC_CHANNELS];
         bool dualMode;
-        uint8_t selectedADC;
+        uint8_t selected_adc;
 
     public:
         template <typename ... T>
@@ -44,21 +44,22 @@ class AdvancedADC {
                 adc_pins[n_channels++] = analogPinToPinName(p);
             }
             dualMode=false;
-            selectedADC=0;
+            selected_adc=0;
         }
         AdvancedADC(): n_channels(0), descr(nullptr) {}
         ~AdvancedADC();
         bool available();
         SampleBuffer read();
-        int begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers, bool do_start=true,uint8_t adcNum=0);
-        int begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers, size_t n_pins, pin_size_t *pins, bool start=true,uint8_t fixed_adc=0) {
+        int getAssignedADC();
+        int begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers, bool do_start=true);
+        int begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers, size_t n_pins, pin_size_t *pins, bool start=true) {
             if (n_pins > AN_MAX_ADC_CHANNELS) n_pins = AN_MAX_ADC_CHANNELS;
             for (size_t i = 0; i < n_pins; ++i) {
                 adc_pins[i] = analogPinToPinName(pins[i]);
             }
 
             n_channels = n_pins;
-            return begin(resolution, sample_rate, n_samples, n_buffers,start,fixed_adc);
+            return begin(resolution, sample_rate, n_samples, n_buffers,start);
         }
         
         void clear();

--- a/src/HALConfig.cpp
+++ b/src/HALConfig.cpp
@@ -167,14 +167,12 @@ static uint32_t ADC_RANK_LUT[] = {
     ADC_REGULAR_RANK_1, ADC_REGULAR_RANK_2, ADC_REGULAR_RANK_3, ADC_REGULAR_RANK_4, ADC_REGULAR_RANK_5
 };
 
-int hal_enable_dual_mode()
-{
+int hal_enable_dual_mode() {
     LL_ADC_SetMultimode(__LL_ADC_COMMON_INSTANCE(ADC1), LL_ADC_MULTI_DUAL_REG_SIMULT);
     return(1);
 }
 
-int hal_disable_dual_mode()
-{
+int hal_disable_dual_mode() {
     LL_ADC_SetMultimode(__LL_ADC_COMMON_INSTANCE(ADC1), LL_ADC_MULTI_INDEPENDENT);
     return(1);
 }

--- a/src/HALConfig.cpp
+++ b/src/HALConfig.cpp
@@ -46,18 +46,18 @@ int hal_tim_config(TIM_HandleTypeDef *tim, uint32_t t_freq) {
     sConfig.MasterSlaveMode         = TIM_MASTERSLAVEMODE_ENABLE;
 
     if (tim->Instance == TIM1) {
-        __HAL_RCC_TIM1_CLK_ENABLE();
+                __HAL_RCC_TIM1_CLK_ENABLE();
     } else if (tim->Instance == TIM2) {
         __HAL_RCC_TIM2_CLK_ENABLE();
-    } else if (tim->Instance == TIM3) {
+            } else if (tim->Instance == TIM3) {
         __HAL_RCC_TIM3_CLK_ENABLE();
-    } else if (tim->Instance == TIM4) {
+            } else if (tim->Instance == TIM4) {
         __HAL_RCC_TIM4_CLK_ENABLE();
-    } else if (tim->Instance == TIM5) {
+            } else if (tim->Instance == TIM5) {
         __HAL_RCC_TIM5_CLK_ENABLE();
-    } else if (tim->Instance == TIM6) {
+            } else if (tim->Instance == TIM6) {
         __HAL_RCC_TIM6_CLK_ENABLE();
-    }
+            }
 
     // Init and config the timer.
     __HAL_TIM_CLEAR_FLAG(tim, TIM_FLAG_UPDATE);
@@ -167,10 +167,22 @@ static uint32_t ADC_RANK_LUT[] = {
     ADC_REGULAR_RANK_1, ADC_REGULAR_RANK_2, ADC_REGULAR_RANK_3, ADC_REGULAR_RANK_4, ADC_REGULAR_RANK_5
 };
 
+int hal_enable_dual_mode()
+{
+    LL_ADC_SetMultimode(__LL_ADC_COMMON_INSTANCE(ADC1), LL_ADC_MULTI_DUAL_REG_SIMULT);
+    return(1);
+}
+
+int hal_disable_dual_mode()
+{
+    LL_ADC_SetMultimode(__LL_ADC_COMMON_INSTANCE(ADC1), LL_ADC_MULTI_INDEPENDENT);
+    return(1);
+}
+
 int hal_adc_config(ADC_HandleTypeDef *adc, uint32_t resolution, uint32_t trigger, PinName *adc_pins, uint32_t n_channels) {
     // Set ADC clock source.
     __HAL_RCC_ADC_CONFIG(RCC_ADCCLKSOURCE_CLKP);
-
+   
     // Enable ADC clock
     if (adc->Instance == ADC1) {
         __HAL_RCC_ADC12_CLK_ENABLE();
@@ -206,7 +218,7 @@ int hal_adc_config(ADC_HandleTypeDef *adc, uint32_t resolution, uint32_t trigger
     sConfig.OffsetNumber = ADC_OFFSET_NONE;
     sConfig.SingleDiff   = ADC_SINGLE_ENDED;
     sConfig.SamplingTime = ADC_SAMPLETIME_8CYCLES_5;
-
+    
     for (size_t rank=0; rank<n_channels; rank++) {
         uint32_t function = pinmap_function(adc_pins[rank], PinMap_ADC);
         uint32_t channel = STM_PIN_CHANNEL(function);

--- a/src/HALConfig.h
+++ b/src/HALConfig.h
@@ -31,5 +31,7 @@ void hal_dma_update_memory(DMA_HandleTypeDef *dma, void *addr);
 int hal_dac_config(DAC_HandleTypeDef *dac, uint32_t channel, uint32_t trigger);
 int hal_adc_config(ADC_HandleTypeDef *adc, uint32_t resolution, uint32_t trigger, PinName *adc_pins, uint32_t n_channels);
 int hal_i2s_config(I2S_HandleTypeDef *i2s, uint32_t sample_rate, uint32_t mode, bool mck_enable);
+int hal_enable_dual_mode();
+int hal_disable_dual_mode();
 
 #endif  // __HAL_CONFIG_H__


### PR DESCRIPTION
The proposed change adds a new class `AdvancedADCDual` class which is used to handle configuring ADC1 and ADC2 and starting them synchronously by enabling Dual mode in the ADC1/2_CCR register.

It works like this:

```cpp
AdvancedADC adc_input[2];
AdvancedADCDual adc_dual;

result = adc_dual.begin(&(adc_input[0]), &(adc_input[1]), sample_resolution, sample_rate, num_samples, QUEUE_DEPTH, 2, &pins);
```

where `pins` is an array of pins numbers.

The AdvancedADCDual `begin()` routine calls the AdvancedADC `begin()` for each instance.  
It configures the first pin in the array on ADC1 and the remaining pins on ADC2.  There was not a cleaner way to do this
without passing two arrays (which is possible).  Finally it calls `start()` on the AdvancedADC mapped to ADC1.

The `AdvancedADC.begin()` routine was modified to take two optional parameters: `do_start` and `adcNum`.
Additionally, a new `start()` routine was added to `AdvancedADC()`.
The `do_start` parameter allows the AdvancedADCDual to hold-off starting the ADC until both are configured.
The `adcNum` is required because you must force the input pins to be mapped to ADC1 and ADC2 for dual mode.
Since both parameters are defaulted, the `AdvancedADC.begin()` remains backward compatible with existing code.

Finally, the `HALConfig.cpp` and `.h` were modified to add two new routines: `hal_enable_dual_mode` and `hal_disable_dual_mode`.
These access the low-level driver to write a 5-bit value to the ADC1/2_CCR register enabling or disabling Dual Mode Simultaneous.

I've tested this, and it seems to work properly.

