### PR TITLE
AdvancedADC: Add sample time argument to ADC constructors.

### DIFF
--- a/src/AdvancedADC.cpp
+++ b/src/AdvancedADC.cpp
@@ -129,7 +129,8 @@ DMABuffer<Sample> &AdvancedADC::read() {
     return NULLBUF;
 }
 
-int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers, bool start) {
+int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples,
+                       size_t n_buffers, bool start, adc_sample_time_t sample_time) {
     
     ADCName instance = ADC_NP;
     // Sanity checks.
@@ -214,7 +215,7 @@ int AdvancedADC::begin(uint32_t resolution, uint32_t sample_rate, size_t n_sampl
     }
 
     // Init and config ADC.
-    if (hal_adc_config(&descr->adc, ADC_RES_LUT[resolution], descr->tim_trig, adc_pins, n_channels) < 0) {
+    if (hal_adc_config(&descr->adc, ADC_RES_LUT[resolution], descr->tim_trig, adc_pins, n_channels, sample_time) < 0) {
         return 0;
     }
 
@@ -268,18 +269,19 @@ AdvancedADC::~AdvancedADC() {
     dac_descr_deinit(descr, true);
 }
 
-int AdvancedADCDual::begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers) {
+int AdvancedADCDual::begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples,
+                           size_t n_buffers, adc_sample_time_t sample_time) {
     // The two ADCs must have the same number of channels.
     if (adc1.channels() != adc2.channels()) {
         return 0;
     }
 
     // Configure the ADCs.
-    if (!adc1.begin(resolution, sample_rate, n_samples, n_buffers, false)) {
+    if (!adc1.begin(resolution, sample_rate, n_samples, n_buffers, false, sample_time)) {
         return 0;
     }
 
-    if (!adc2.begin(resolution, sample_rate, n_samples, n_buffers, false)) {
+    if (!adc2.begin(resolution, sample_rate, n_samples, n_buffers, false, sample_time)) {
         adc1.stop();
         return 0;
     }

--- a/src/AdvancedADC.h
+++ b/src/AdvancedADC.h
@@ -26,6 +26,17 @@
 
 struct adc_descr_t;
 
+typedef enum {
+    AN_ADC_SAMPLETIME_1_5 = ADC_SAMPLETIME_1CYCLE_5,
+    AN_ADC_SAMPLETIME_2_5 = ADC_SAMPLETIME_2CYCLES_5,
+    AN_ADC_SAMPLETIME_8_5 = ADC_SAMPLETIME_8CYCLES_5,
+    AN_ADC_SAMPLETIME_16_5 = ADC_SAMPLETIME_16CYCLES_5,
+    AN_ADC_SAMPLETIME_32_5 = ADC_SAMPLETIME_32CYCLES_5,
+    AN_ADC_SAMPLETIME_64_5 = ADC_SAMPLETIME_64CYCLES_5,
+    AN_ADC_SAMPLETIME_387_5 = ADC_SAMPLETIME_387CYCLES_5,
+    AN_ADC_SAMPLETIME_810_5 = ADC_SAMPLETIME_810CYCLES_5,
+} adc_sample_time_t;
+
 class AdvancedADC {
     private:
         size_t n_channels;
@@ -49,9 +60,10 @@ class AdvancedADC {
         bool available();
         SampleBuffer read();
         int begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples,
-                size_t n_buffers, bool start=true);
+                  size_t n_buffers, bool start=true, adc_sample_time_t sample_time=AN_ADC_SAMPLETIME_8_5);
         int begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples,
-                size_t n_buffers, size_t n_pins, pin_size_t *pins, bool start=true) {
+                  size_t n_buffers, size_t n_pins, pin_size_t *pins, bool start=true,
+                  adc_sample_time_t sample_time=AN_ADC_SAMPLETIME_8_5) {
             if (n_pins > AN_MAX_ADC_CHANNELS) {
                 n_pins = AN_MAX_ADC_CHANNELS;
             }
@@ -60,7 +72,7 @@ class AdvancedADC {
             }
 
             n_channels = n_pins;
-            return begin(resolution, sample_rate, n_samples, n_buffers, start);
+            return begin(resolution, sample_rate, n_samples, n_buffers, start, sample_time);
         }
         int start(uint32_t sample_rate);
         int stop();
@@ -79,7 +91,8 @@ class AdvancedADCDual {
             n_channels(0), adc1(adc1_in), adc2(adc2_in) {
         }
         ~AdvancedADCDual();
-        int begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers);
+        int begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples,
+                  size_t n_buffers, adc_sample_time_t sample_time=AN_ADC_SAMPLETIME_8_5);
         int stop();
 };
 

--- a/src/HALConfig.cpp
+++ b/src/HALConfig.cpp
@@ -170,7 +170,8 @@ static uint32_t ADC_RANK_LUT[] = {
     ADC_REGULAR_RANK_13, ADC_REGULAR_RANK_14, ADC_REGULAR_RANK_15, ADC_REGULAR_RANK_16
 };
 
-int hal_adc_config(ADC_HandleTypeDef *adc, uint32_t resolution, uint32_t trigger, PinName *adc_pins, uint32_t n_channels) {
+int hal_adc_config(ADC_HandleTypeDef *adc, uint32_t resolution, uint32_t trigger,
+                   PinName *adc_pins, uint32_t n_channels, uint32_t sample_time) {
     // Set ADC clock source.
     __HAL_RCC_ADC_CONFIG(RCC_ADCCLKSOURCE_CLKP);
 
@@ -208,7 +209,7 @@ int hal_adc_config(ADC_HandleTypeDef *adc, uint32_t resolution, uint32_t trigger
     sConfig.Offset       = 0;
     sConfig.OffsetNumber = ADC_OFFSET_NONE;
     sConfig.SingleDiff   = ADC_SINGLE_ENDED;
-    sConfig.SamplingTime = ADC_SAMPLETIME_8CYCLES_5;
+    sConfig.SamplingTime = sample_time;
 
     for (size_t rank=0; rank<n_channels; rank++) {
         uint32_t function = pinmap_function(adc_pins[rank], PinMap_ADC);

--- a/src/HALConfig.h
+++ b/src/HALConfig.h
@@ -29,7 +29,8 @@ size_t hal_dma_get_ct(DMA_HandleTypeDef *dma);
 void hal_dma_enable_dbm(DMA_HandleTypeDef *dma, void *m0 = nullptr, void *m1 = nullptr);
 void hal_dma_update_memory(DMA_HandleTypeDef *dma, void *addr);
 int hal_dac_config(DAC_HandleTypeDef *dac, uint32_t channel, uint32_t trigger);
-int hal_adc_config(ADC_HandleTypeDef *adc, uint32_t resolution, uint32_t trigger, PinName *adc_pins, uint32_t n_channels);
+int hal_adc_config(ADC_HandleTypeDef *adc, uint32_t resolution, uint32_t trigger,
+                   PinName *adc_pins, uint32_t n_channels, uint32_t sample_time);
 int hal_adc_enable_dual_mode(bool enable);
 int hal_i2s_config(I2S_HandleTypeDef *i2s, uint32_t sample_rate, uint32_t mode, bool mck_enable);
 


### PR DESCRIPTION
Fixes  #62.